### PR TITLE
Optimizations

### DIFF
--- a/Mandelbrot_render.h
+++ b/Mandelbrot_render.h
@@ -1091,10 +1091,10 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 			cy = _mm256_load_pd(cy_mem); \
 		}
 
-		t1 = _mm256_or_pd((__m256d)s1_count, _mm256_cmp_pd(s1_mag, four_double, _CMP_GT_OS));
+		t1 = _mm256_or_pd((__m256d)s1_count, _mm256_cmpgt_epi64(s1_mag, four_double));
 		TEST(s1_x, s1_y, s1_cx, s1_cy, s1_dx, s1_dy, s1_mag, s1_count);
 
-		t1 = _mm256_or_pd((__m256d)s2_count, _mm256_cmp_pd(s2_mag, four_double, _CMP_GT_OS));
+		t1 = _mm256_or_pd((__m256d)s2_count, _mm256_cmpgt_epi64(s2_mag, four_double));
 		TEST(s2_x, s2_y, s2_cx, s2_cy, s2_dx, s2_dy, s2_mag, s2_count);
 
 		s1_count = _mm256_sub_epi64(s1_count, one_int64);

--- a/Mandelbrot_render.h
+++ b/Mandelbrot_render.h
@@ -28,7 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-
+#include <stdio.h>
 #include <immintrin.h>
 #include "Mandelbrot.h"
 
@@ -1030,24 +1030,26 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 	iterations_t* pp = mse.p;
 	reset(pp, width, render_width, render_height);
 	iterations--;
-	__m256d s1_x = _mm256_setzero_pd();
-	__m256d s1_y = _mm256_setzero_pd();
-	__m256d s1_x_squared = _mm256_setzero_pd();
-	__m256d s1_y_squared = _mm256_setzero_pd();
-	__m256d s1_mag = _mm256_setzero_pd();
-	__m256i s1_count = _mm256_set1_epi64x(iterations + 2);
-	__m256d s2_x = _mm256_setzero_pd();
-	__m256d s2_y = _mm256_setzero_pd();
-	__m256d s2_x_squared = _mm256_setzero_pd();
-	__m256d s2_y_squared = _mm256_setzero_pd();
-	__m256d s2_mag = _mm256_setzero_pd();
-	__m256i s2_count = _mm256_set1_epi64x(iterations + 2);
-	__m256i one_int64 = _mm256_set1_epi64x(1);
+	__m256d s1_x        = _mm256_setzero_pd();
+	__m256d s1_y        = _mm256_setzero_pd();
+	__m256d s1_mag      = _mm256_setzero_pd();
+	__m256i s1_count    = _mm256_set1_epi64x(iterations + 2);
+	__m256d s2_x        = _mm256_setzero_pd();
+	__m256d s2_y        = _mm256_setzero_pd();
+	__m256d s2_mag      = _mm256_setzero_pd();
+	__m256i s2_count    = _mm256_set1_epi64x(iterations + 2);
+	__m256i one_int64   = _mm256_set1_epi64x(1);
 	__m256d four_double = _mm256_set1_pd(4.0);
+	__m256i t1, t2;
 	uint32_t s1_dx[4] = {}, s1_dy[4] = {};
 	uint32_t s2_dx[4] = {}, s2_dy[4] = {};
-	double cx_mem[4] __attribute__((__aligned__(32)));
-	double cy_mem[4] __attribute__((__aligned__(32)));
+	double   cx_mem[4]    __attribute__((__aligned__(32)));
+	double   cy_mem[4]    __attribute__((__aligned__(32)));
+	double   x_mem[4]     __attribute__((__aligned__(32)));
+	double   y_mem[4]     __attribute__((__aligned__(32)));
+	double   mag_mem[4]   __attribute__((__aligned__(32)));
+	uint64_t count_mem[4] __attribute__((__aligned__(32)));
+
 	mse.get_next_point(cx_mem[0], cy_mem[0], s1_dx[0], s1_dy[0]);
 	mse.get_next_point(cx_mem[1], cy_mem[1], s1_dx[1], s1_dy[1]);
 	mse.get_next_point(cx_mem[2], cy_mem[2], s1_dx[2], s1_dy[2]);
@@ -1061,92 +1063,57 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 	__m256d s2_cx = *(__m256d * )cx_mem;
 	__m256d s2_cy = *(__m256d * )cy_mem;
 	while(true) {
-		__m256d cmp2 = _mm256_or_pd((__m256d)s1_count, _mm256_cmp_pd(s1_mag, four_double, _CMP_GT_OS));
-		if(!_mm256_testz_pd(cmp2, cmp2)) {
-			uint32_t mask = _mm256_movemask_pd(cmp2);
-			_mm256_store_pd(cx_mem, s1_cx);
-			_mm256_store_pd(cy_mem, s1_cy);
-			double s1_x_mem[4] __attribute__((__aligned__(32)));
-			double s1_y_mem[4] __attribute__((__aligned__(32)));
-			uint64_t s1_count_mem[4] __attribute__((__aligned__(32)));
-			double s1_x_squared_mem[4] __attribute__((__aligned__(32)));
-			double s1_y_squared_mem[4] __attribute__((__aligned__(32)));
-			_mm256_store_pd(s1_x_mem, s1_x);
-			_mm256_store_pd(s1_y_mem, s1_y);
-			_mm256_store_si256((__m256i * )s1_count_mem, s1_count);
-			_mm256_store_pd(s1_x_squared_mem, s1_x_squared);
-			_mm256_store_pd(s1_y_squared_mem, s1_y_squared);
-			while(mask != 0) {
-				uint32_t b = __builtin_ctz(mask);
-				pp[s1_dx[b] + s1_dy[b] * width] = iterations - s1_count_mem[b];
-				if(!mse.get_next_point(cx_mem[b], cy_mem[b], s1_dx[b], s1_dy[b])) {
-					cleanup(mse);
-					return;
-				}
-				s1_count_mem[b] = iterations + 2;
-				s1_x_mem[b] = s1_y_mem[b] = s1_x_squared_mem[b] = s1_y_squared_mem[b] = 0;
-				mask = mask&~(1U<<b);
-			}
-			s1_x = _mm256_load_pd(s1_x_mem);
-			s1_y = _mm256_load_pd(s1_y_mem);
-			s1_count = _mm256_load_si256((__m256i * )s1_count_mem);
-			s1_x_squared = _mm256_load_pd(s1_x_squared_mem);
-			s1_y_squared = _mm256_load_pd(s1_y_squared_mem);
-			s1_cx = _mm256_load_pd(cx_mem);
-			s1_cy = _mm256_load_pd(cy_mem);
+#		define TEST(x,y,cx,cy,dx,dy,mag,count) \
+		if(!_mm256_testz_pd(t1, t1)) [[unlikely]] { \
+			uint32_t mask = _mm256_movemask_pd(t1); \
+			_mm256_store_pd(cx_mem, cx); \
+			_mm256_store_pd(cy_mem, cy); \
+			_mm256_store_pd(x_mem, x); \
+			_mm256_store_pd(y_mem, y); \
+			_mm256_store_si256((__m256i * )count_mem, count); \
+			_mm256_store_pd(mag_mem, mag); \
+			while(mask != 0) { \
+				uint32_t b = __builtin_ctz(mask); \
+				pp[dx[b] + dy[b] * width] = iterations - count_mem[b]; \
+				if(!mse.get_next_point(cx_mem[b], cy_mem[b], dx[b], dy[b])) { \
+					cleanup(mse); \
+					return; \
+				} \
+				count_mem[b] = iterations + 2; \
+				x_mem[b] = y_mem[b] = mag_mem[b] = 0; \
+				mask = mask & ~(1U<<b); \
+			} \
+			x = _mm256_load_pd(x_mem); \
+			y = _mm256_load_pd(y_mem); \
+			count = _mm256_load_si256((__m256i * )count_mem); \
+			mag = _mm256_load_pd(mag_mem); \
+			cx = _mm256_load_pd(cx_mem); \
+			cy = _mm256_load_pd(cy_mem); \
 		}
-		cmp2 = _mm256_or_pd((__m256d)s2_count, _mm256_cmp_pd(s2_mag, four_double, _CMP_GT_OS));
-		if(!_mm256_testz_pd(cmp2, cmp2)) {
-			uint32_t mask = _mm256_movemask_pd(cmp2);
-			_mm256_store_pd(cx_mem, s2_cx);
-			_mm256_store_pd(cy_mem, s2_cy);
-			double s2_x_mem[4] __attribute__((__aligned__(32)));
-			double s2_y_mem[4] __attribute__((__aligned__(32)));
-			uint64_t s2_count_mem[4] __attribute__((__aligned__(32)));
-			double s2_x_squared_mem[4] __attribute__((__aligned__(32)));
-			double s2_y_squared_mem[4] __attribute__((__aligned__(32)));
-			_mm256_store_pd(s2_x_mem, s2_x);
-			_mm256_store_pd(s2_y_mem, s2_y);
-			_mm256_store_si256((__m256i * )s2_count_mem, s2_count);
-			_mm256_store_pd(s2_x_squared_mem, s2_x_squared);
-			_mm256_store_pd(s2_y_squared_mem, s2_y_squared);
-			while(mask != 0) {
-				uint32_t b = __builtin_ctz(mask);
-				pp[s2_dx[b] + s2_dy[b] * width] = iterations - s2_count_mem[b];
-				if(!mse.get_next_point(cx_mem[b], cy_mem[b], s2_dx[b], s2_dy[b])) {
-					cleanup(mse);
-					return;
-				}
-				s2_count_mem[b] = iterations + 2;
-				s2_x_mem[b] = s2_y_mem[b] = s2_x_squared_mem[b] = s2_y_squared_mem[b] = 0;
-				mask = mask&~(1U<<b);
-			}
-			s2_x = _mm256_load_pd(s2_x_mem);
-			s2_y = _mm256_load_pd(s2_y_mem);
-			s2_count = _mm256_load_si256((__m256i * )s2_count_mem);
-			s2_x_squared = _mm256_load_pd(s2_x_squared_mem);
-			s2_y_squared = _mm256_load_pd(s2_y_squared_mem);
-			s2_cx = _mm256_load_pd(cx_mem);
-			s2_cy = _mm256_load_pd(cy_mem);
-		}
-		// s1_mag = s1_x_squared + s1_y_squared;
-		s1_mag = _mm256_add_pd(s1_x_squared, s1_y_squared);
-		s2_mag = _mm256_add_pd(s2_x_squared, s2_y_squared);
-		// Decrement counter
+
+		t1 = _mm256_or_pd((__m256d)s1_count, _mm256_cmp_pd(s1_mag, four_double, _CMP_GT_OS));
+		TEST(s1_x, s1_y, s1_cx, s1_cy, s1_dx, s1_dy, s1_mag, s1_count);
+
+		t1 = _mm256_or_pd((__m256d)s2_count, _mm256_cmp_pd(s2_mag, four_double, _CMP_GT_OS));
+		TEST(s2_x, s2_y, s2_cx, s2_cy, s2_dx, s2_dy, s2_mag, s2_count);
+
 		s1_count = _mm256_sub_epi64(s1_count, one_int64);
+		s1_mag   = _mm256_fmadd_pd(s1_x, s1_x, s1_y);
+		t1       = _mm256_add_pd(s1_x, s1_x);
+		t1       = _mm256_fmadd_pd(t1, s1_y, s1_cy);
+		s1_y     = _mm256_mul_pd(s1_y, s1_y);
+		t2       = _mm256_fmsub_pd(s1_x, s1_x, s1_y);
+		s1_x     = _mm256_add_pd(t2, s1_cx);
+		s1_y     = t1;
+
 		s2_count = _mm256_sub_epi64(s2_count, one_int64);
-		// s1_y_squared = s1_y * s1_y;
-		s1_y_squared = _mm256_mul_pd(s1_y, s1_y);
-		s2_y_squared = _mm256_mul_pd(s2_y, s2_y);
-		// s1_x_squared = s1_x * s1_x;
-		s1_x_squared = _mm256_mul_pd(s1_x, s1_x);
-		s2_x_squared = _mm256_mul_pd(s2_x, s2_x);
-		// s1_y = 2 * s1_y * s1_x + s1_cy;
-		s1_y = _mm256_fmadd_pd(_mm256_add_pd(s1_x, s1_x), s1_y, s1_cy);
-		s2_y = _mm256_fmadd_pd(_mm256_add_pd(s2_x, s2_x), s2_y, s2_cy);
-		// s1_x = s1_x_squared - s1_y_squared + s1_cx;
-		s1_x = _mm256_sub_pd(s1_x_squared, _mm256_sub_pd(s1_y_squared, s1_cx));
-		s2_x = _mm256_sub_pd(s2_x_squared, _mm256_sub_pd(s2_y_squared, s2_cx));
+		s2_mag   = _mm256_fmadd_pd(s2_x, s2_x, s2_y);
+		t1       = _mm256_add_pd(s2_x, s2_x);
+		t1       = _mm256_fmadd_pd(t1, s2_y, s2_cy);
+		s2_y     = _mm256_mul_pd(s2_y, s2_y);
+		t2       = _mm256_fmsub_pd(s2_x, s2_x, s2_y);
+		s2_x     = _mm256_add_pd(t2, s2_cx);
+		s2_y     = t1;
 	}
 }
 


### PR DESCRIPTION
I found a few optimizations. First of all, eliminating an instruction. The original code does:

```c
t1  = mul(x, x)        // x^2
t2  = mul(y, y)        // y^2
t3  = add(x, x)        // 2x
y   = fmadd(t3, y, cy) // 2xy + cy
t3  = sub(t2, cx)      // y^2 - cx
x   = sub(t1, t3)      // x^2 - y^2 + cx
mag = add(t1, t2)      // x^2 + y^2
```

That's 1 fmul, 2 mul and 4 add/sub. Each runs 1 µop on p01, with a latency of 4.

Critical path is `mul > sub > sub` for x,  `add > fmadd` for y and `mul > add` for mag.

You can rewrite this as:

```c
t1  = add(x, x)         // 2x
t1  = fmadd(t1, y, cy)  // 2xy + cy
y   = mul(y, y)         // y^2
mag = fmadd(x, x, y)    // x^2 + y^2
t2  = fmsub(x, x, y)    // x^2 - y^2
x   = add(t2, cx)       // x^2 - y^2 + cx
y   = t1
```

Now it's 3 fmul, 1 mul and 2 add/sub. Critical path is `mul > fmsub > add` for x, `add > fmadd` for y and `mul > fmadd` for mag.

You mentioned register pressure. I noticed that clang is spilling some things to memory when it's not really necessary.

- Added an `[[unlikely]]` hint to the "sheep race" part.
- Minimized the number of `__m256`s to help the compiler with register allocation.
- No need to store and reload `s1_x_squared`, `s1_y_squared` or `s1_mag` in the "sheep race" code.
- Replaced `cmppd` with `pcmpgtq` to relieve port pressure on p0/p1. Floats can be compared using integer logic, provided both operands are non-negative and non-NaN.

The code no longer spills registers and is about 10% faster.