### PR TITLE
Optimized render_avx_sheeprace3, replaced macros with inline functions

### DIFF
--- a/Mandelbrot_fastest.cpp
+++ b/Mandelbrot_fastest.cpp
@@ -32,6 +32,6 @@
 #include "MandelbrotStateEngineSimple.h"
 
 void Mandelbrot::fastest(iterations_t iterations, uint32_t render_x, uint32_t render_y, uint32_t render_width, uint32_t render_height) {
-	render_avx_sheeprace2<MandelbrotStateEngineSimple>(iterations,render_x,render_y,render_width,render_height);
+	render_avx_sheeprace3<MandelbrotStateEngineSimple>(iterations,render_x,render_y,render_width,render_height);
 }
 

--- a/Mandelbrot_render.h
+++ b/Mandelbrot_render.h
@@ -32,6 +32,8 @@
 #include <immintrin.h>
 #include "Mandelbrot.h"
 
+#define RUN_ITERS 32 // number of iterations between iteration overflow checks
+
 template<class M> void Mandelbrot::render1(iterations_t iterations, uint32_t render_x, uint32_t render_y, uint32_t render_width, uint32_t render_height) {
 	if(render_width == 0) {
 		render_width = width - render_x;
@@ -1090,10 +1092,6 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 
 		t1 = _mm256_or_pd((__m256d)s1_count, _mm256_cmpgt_epi64(s1_mag, four_double));
 		TEST(s1_x, s1_y, s1_cx, s1_cy, s1_dx, s1_dy, s1_count);
-
-		t1 = _mm256_or_pd((__m256d)s2_count, _mm256_cmpgt_epi64(s2_mag, four_double));
-		TEST(s2_x, s2_y, s2_cx, s2_cy, s2_dx, s2_dy, s2_count);
-
 		s1_count = _mm256_sub_epi64(s1_count, one_int64);
 		s1_mag   = _mm256_fmadd_pd(s1_x, s1_x, s1_y);
 		t1       = _mm256_add_pd(s1_x, s1_x);
@@ -1103,6 +1101,8 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 		s1_x     = _mm256_add_pd(t2, s1_cx);
 		s1_y     = t1;
 
+		t1 = _mm256_or_pd((__m256d)s2_count, _mm256_cmpgt_epi64(s2_mag, four_double));
+		TEST(s2_x, s2_y, s2_cx, s2_cy, s2_dx, s2_dy, s2_count);
 		s2_count = _mm256_sub_epi64(s2_count, one_int64);
 		s2_mag   = _mm256_fmadd_pd(s2_x, s2_x, s2_y);
 		t1       = _mm256_add_pd(s2_x, s2_x);
@@ -1114,38 +1114,47 @@ template<class M> void Mandelbrot::render_avx_sheeprace2(iterations_t iterations
 	}
 }
 
-template<class M> __attribute__((noinline)) bool update_avx_stream(M& mse, uint32_t index, uint32_t mask,__m256d& s1_cx,__m256d& s1_cy,__m256d& s1_x,__m256d& s1_y,__m256d& s1_x_squared,__m256d& s1_y_squared,__m256i& s1_count) {
+inline void update_point(__m256d &x, __m256d &y, __m256d &cx, __m256d &cy, __m256i &t1) {
+	__m256i t2;
+	t1    = _mm256_add_pd(x, x);
+	t1    = _mm256_fmadd_pd(t1, y, cy);
+	y     = _mm256_mul_pd(y, y);
+	t2    = _mm256_fmsub_pd(x, x, y);
+	x     = _mm256_add_pd(t2, cx);
+	y     = t1;
+	t1    = _mm256_fmadd_pd(x, x, y);
+	t1    = _mm256_cmpgt_epi64(t1, _mm256_set1_pd(4.0));
+}
+
+template<class M> inline bool update_avx_stream(M& mse, __m256d &x, __m256d &y, __m256d &cx, __m256d &cy, __m256i mask_vec, int i, uint32_t *dx, uint32_t *dy, uint64_t *count, iterations_t iterations, int width) {
 	double cx_mem[4] __attribute__((__aligned__(32)));
 	double cy_mem[4] __attribute__((__aligned__(32)));
-	double s1_x_mem[4] __attribute__((__aligned__(32)));
-	double s1_y_mem[4] __attribute__((__aligned__(32)));
-	uint64_t s1_count_mem[4] __attribute__((__aligned__(32)));
-	double s1_x_squared_mem[4] __attribute__((__aligned__(32)));
-	double s1_y_squared_mem[4] __attribute__((__aligned__(32)));
-	_mm256_store_pd(cx_mem, s1_cx);
-	_mm256_store_pd(cy_mem, s1_cy);
-	_mm256_store_pd(s1_x_mem, s1_x);
-	_mm256_store_pd(s1_y_mem, s1_y);
-	_mm256_store_si256((__m256i * )s1_count_mem, s1_count);
-	_mm256_store_pd(s1_x_squared_mem, s1_x_squared);
-	_mm256_store_pd(s1_y_squared_mem, s1_y_squared);
+	double x_mem[4]  __attribute__((__aligned__(32)));
+	double y_mem[4]  __attribute__((__aligned__(32)));
+
+	uint32_t mask = _mm256_movemask_pd(mask_vec);
+	_mm256_store_pd(cx_mem, cx);
+	_mm256_store_pd(cy_mem, cy);
+	_mm256_store_pd(x_mem, x);
+	_mm256_store_pd(y_mem, y);
+
 	while(mask != 0) {
 		uint32_t b = __builtin_ctz(mask);
-		mse.p[mse.dx[index][b] + mse.dy[index][b] * mse.stored_width] = mse.stored_iterations - s1_count_mem[b];
-		if(!mse.get_next_point(cx_mem[b], cy_mem[b], mse.dx[index][b], mse.dy[index][b])) {
+
+		mse.p[dx[b] + dy[b] * width] = (i + count[b]>iterations) ? iterations : i + count[b];
+		if(!mse.get_next_point(cx_mem[b], cy_mem[b], dx[b], dy[b])) {
+			mse.cleanup();
 			return false;
 		}
-		s1_count_mem[b] = mse.stored_iterations + 2;
-		s1_x_mem[b] = s1_y_mem[b] = s1_x_squared_mem[b] = s1_y_squared_mem[b] = 0;
-		mask = mask&~(1U<<b);
+		count[b] = -i;
+		x_mem[b] = y_mem[b] = 0;
+		mask = mask & ~(1U<<b);
 	}
-	s1_x = _mm256_load_pd(s1_x_mem);
-	s1_y = _mm256_load_pd(s1_y_mem);
-	s1_count = _mm256_load_si256((__m256i * )s1_count_mem);
-	s1_x_squared = _mm256_load_pd(s1_x_squared_mem);
-	s1_y_squared = _mm256_load_pd(s1_y_squared_mem);
-	s1_cx = _mm256_load_pd(cx_mem);
-	s1_cy = _mm256_load_pd(cy_mem);
+	x     = _mm256_load_pd(x_mem);
+	y     = _mm256_load_pd(y_mem);
+	cx    = _mm256_load_pd(cx_mem);
+	cy    = _mm256_load_pd(cy_mem);
+
 	return true;
 }
 
@@ -1159,178 +1168,86 @@ template<class M> void Mandelbrot::render_avx_sheeprace3(iterations_t iterations
 	M mse(p, width, height, render_x, render_y, render_width, render_height, xs, ys, inc, iterations);
 	iterations_t* pp = mse.p;
 	reset(pp, width, render_width, render_height);
-	iterations--;
-	__m256d s1_x = _mm256_setzero_pd();
-	__m256d s1_y = _mm256_setzero_pd();
-	__m256d s1_x_squared = _mm256_setzero_pd();
-	__m256d s1_y_squared = _mm256_setzero_pd();
-	__m256d s1_mag = _mm256_setzero_pd();
-	__m256i s1_count = _mm256_set1_epi64x(iterations + 2);
-	__m256d s2_x = _mm256_setzero_pd();
-	__m256d s2_y = _mm256_setzero_pd();
-	__m256d s2_x_squared = _mm256_setzero_pd();
-	__m256d s2_y_squared = _mm256_setzero_pd();
-	__m256d s2_mag = _mm256_setzero_pd();
-	__m256i s2_count = _mm256_set1_epi64x(iterations + 2);
-	__m256d s3_x = _mm256_setzero_pd();
-	__m256d s3_y = _mm256_setzero_pd();
-	__m256d s3_x_squared = _mm256_setzero_pd();
-	__m256d s3_y_squared = _mm256_setzero_pd();
-	__m256d s3_mag = _mm256_setzero_pd();
-	__m256i s3_count = _mm256_set1_epi64x(iterations + 2);
-	__m256i one_int64 = _mm256_set1_epi64x(1);
-	__m256d four_double = _mm256_set1_pd(4.0);
+	__m256d s1_x        = _mm256_setzero_pd();
+	__m256d s1_y        = _mm256_setzero_pd();
+	__m256d s2_x        = _mm256_setzero_pd();
+	__m256d s2_y        = _mm256_setzero_pd();
+	__m256d s3_x        = _mm256_setzero_pd();
+	__m256d s3_y        = _mm256_setzero_pd();
+	__m256d run_iters   = _mm256_set1_epi64x(RUN_ITERS);
+	__m256d max_iters   = _mm256_set1_epi64x(iterations);
+	__m256i t1;
 	uint32_t s1_dx[4] = {}, s1_dy[4] = {};
 	uint32_t s2_dx[4] = {}, s2_dy[4] = {};
 	uint32_t s3_dx[4] = {}, s3_dy[4] = {};
-	double cx_mem[4] __attribute__((__aligned__(32)));
-	double cy_mem[4] __attribute__((__aligned__(32)));
+	double   cx_mem[4]    __attribute__((__aligned__(32)));
+	double   cy_mem[4]    __attribute__((__aligned__(32)));
+	uint64_t s1_count[4] __attribute__((__aligned__(32))) = {0};
+	uint64_t s2_count[4] __attribute__((__aligned__(32))) = {0};
+	uint64_t s3_count[4] __attribute__((__aligned__(32))) = {0};
+
 	mse.get_next_point(cx_mem[0], cy_mem[0], s1_dx[0], s1_dy[0]);
 	mse.get_next_point(cx_mem[1], cy_mem[1], s1_dx[1], s1_dy[1]);
 	mse.get_next_point(cx_mem[2], cy_mem[2], s1_dx[2], s1_dy[2]);
 	mse.get_next_point(cx_mem[3], cy_mem[3], s1_dx[3], s1_dy[3]);
-	__m256d s1_cx = *(__m256d * )cx_mem;
-	__m256d s1_cy = *(__m256d * )cy_mem;
+	__m256d s1_cx = _mm256_load_pd(cx_mem);
+	__m256d s1_cy = _mm256_load_pd(cy_mem);
 	mse.get_next_point(cx_mem[0], cy_mem[0], s2_dx[0], s2_dy[0]);
 	mse.get_next_point(cx_mem[1], cy_mem[1], s2_dx[1], s2_dy[1]);
 	mse.get_next_point(cx_mem[2], cy_mem[2], s2_dx[2], s2_dy[2]);
 	mse.get_next_point(cx_mem[3], cy_mem[3], s2_dx[3], s2_dy[3]);
-	__m256d s2_cx = *(__m256d * )cx_mem;
-	__m256d s2_cy = *(__m256d * )cy_mem;
+	__m256d s2_cx = _mm256_load_pd(cx_mem);
+	__m256d s2_cy = _mm256_load_pd(cy_mem);
 	mse.get_next_point(cx_mem[0], cy_mem[0], s3_dx[0], s3_dy[0]);
 	mse.get_next_point(cx_mem[1], cy_mem[1], s3_dx[1], s3_dy[1]);
 	mse.get_next_point(cx_mem[2], cy_mem[2], s3_dx[2], s3_dy[2]);
 	mse.get_next_point(cx_mem[3], cy_mem[3], s3_dx[3], s3_dy[3]);
-	__m256d s3_cx = *(__m256d * )cx_mem;
-	__m256d s3_cy = *(__m256d * )cy_mem;
+	__m256d s3_cx = _mm256_load_pd(cx_mem);
+	__m256d s3_cy = _mm256_load_pd(cy_mem);
+
 	while(true) {
-		__m256d cmp2 = _mm256_or_pd((__m256d)s1_count, _mm256_cmp_pd(s1_mag, four_double, _CMP_GT_OS));
-		if(!_mm256_testz_pd(cmp2, cmp2)) {
-			uint32_t mask = _mm256_movemask_pd(cmp2);
-			_mm256_store_pd(cx_mem, s1_cx);
-			_mm256_store_pd(cy_mem, s1_cy);
-			double s1_x_mem[4] __attribute__((__aligned__(32)));
-			double s1_y_mem[4] __attribute__((__aligned__(32)));
-			uint64_t s1_count_mem[4] __attribute__((__aligned__(32)));
-			double s1_x_squared_mem[4] __attribute__((__aligned__(32)));
-			double s1_y_squared_mem[4] __attribute__((__aligned__(32)));
-			_mm256_store_pd(s1_x_mem, s1_x);
-			_mm256_store_pd(s1_y_mem, s1_y);
-			_mm256_store_si256((__m256i * )s1_count_mem, s1_count);
-			_mm256_store_pd(s1_x_squared_mem, s1_x_squared);
-			_mm256_store_pd(s1_y_squared_mem, s1_y_squared);
-			while(mask != 0) {
-				uint32_t b = __builtin_ctz(mask);
-				pp[s1_dx[b] + s1_dy[b] * width] = iterations - s1_count_mem[b];
-				if(!mse.get_next_point(cx_mem[b], cy_mem[b], s1_dx[b], s1_dy[b])) {
-					cleanup(mse);
+		for (int i=0; i<RUN_ITERS; i++) {
+			update_point(s1_x, s1_y, s1_cx, s1_cy, t1);
+			if(!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+				if (!update_avx_stream<M>(mse, s1_x, s1_y, s1_cx, s1_cy, t1, i+1, s1_dx, s1_dy, s1_count, iterations, width)) {
 					return;
 				}
-				s1_count_mem[b] = iterations + 2;
-				s1_x_mem[b] = s1_y_mem[b] = s1_x_squared_mem[b] = s1_y_squared_mem[b] = 0;
-				mask = mask&~(1U<<b);
 			}
-			s1_x = _mm256_load_pd(s1_x_mem);
-			s1_y = _mm256_load_pd(s1_y_mem);
-			s1_count = _mm256_load_si256((__m256i * )s1_count_mem);
-			s1_x_squared = _mm256_load_pd(s1_x_squared_mem);
-			s1_y_squared = _mm256_load_pd(s1_y_squared_mem);
-			s1_cx = _mm256_load_pd(cx_mem);
-			s1_cy = _mm256_load_pd(cy_mem);
-		}
-		cmp2 = _mm256_or_pd((__m256d)s2_count, _mm256_cmp_pd(s2_mag, four_double, _CMP_GT_OS));
-		if(!_mm256_testz_pd(cmp2, cmp2)) {
-			uint32_t mask = _mm256_movemask_pd(cmp2);
-			_mm256_store_pd(cx_mem, s2_cx);
-			_mm256_store_pd(cy_mem, s2_cy);
-			double s2_x_mem[4] __attribute__((__aligned__(32)));
-			double s2_y_mem[4] __attribute__((__aligned__(32)));
-			uint64_t s2_count_mem[4] __attribute__((__aligned__(32)));
-			double s2_x_squared_mem[4] __attribute__((__aligned__(32)));
-			double s2_y_squared_mem[4] __attribute__((__aligned__(32)));
-			_mm256_store_pd(s2_x_mem, s2_x);
-			_mm256_store_pd(s2_y_mem, s2_y);
-			_mm256_store_si256((__m256i * )s2_count_mem, s2_count);
-			_mm256_store_pd(s2_x_squared_mem, s2_x_squared);
-			_mm256_store_pd(s2_y_squared_mem, s2_y_squared);
-			while(mask != 0) {
-				uint32_t b = __builtin_ctz(mask);
-				pp[s2_dx[b] + s2_dy[b] * width] = iterations - s2_count_mem[b];
-				if(!mse.get_next_point(cx_mem[b], cy_mem[b], s2_dx[b], s2_dy[b])) {
-					cleanup(mse);
+
+			update_point(s2_x, s2_y, s2_cx, s2_cy, t1);
+			if(!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+				if (!update_avx_stream<M>(mse, s2_x, s2_y, s2_cx, s2_cy, t1, i+1, s2_dx, s2_dy, s2_count, iterations, width)) {
 					return;
 				}
-				s2_count_mem[b] = iterations + 2;
-				s2_x_mem[b] = s2_y_mem[b] = s2_x_squared_mem[b] = s2_y_squared_mem[b] = 0;
-				mask = mask&~(1U<<b);
 			}
-			s2_x = _mm256_load_pd(s2_x_mem);
-			s2_y = _mm256_load_pd(s2_y_mem);
-			s2_count = _mm256_load_si256((__m256i * )s2_count_mem);
-			s2_x_squared = _mm256_load_pd(s2_x_squared_mem);
-			s2_y_squared = _mm256_load_pd(s2_y_squared_mem);
-			s2_cx = _mm256_load_pd(cx_mem);
-			s2_cy = _mm256_load_pd(cy_mem);
-		}
-		cmp2 = _mm256_or_pd((__m256d)s3_count, _mm256_cmp_pd(s3_mag, four_double, _CMP_GT_OS));
-		if(!_mm256_testz_pd(cmp2, cmp2)) {
-			uint32_t mask = _mm256_movemask_pd(cmp2);
-			_mm256_store_pd(cx_mem, s3_cx);
-			_mm256_store_pd(cy_mem, s3_cy);
-			double s3_x_mem[4] __attribute__((__aligned__(32)));
-			double s3_y_mem[4] __attribute__((__aligned__(32)));
-			uint64_t s3_count_mem[4] __attribute__((__aligned__(32)));
-			double s3_x_squared_mem[4] __attribute__((__aligned__(32)));
-			double s3_y_squared_mem[4] __attribute__((__aligned__(32)));
-			_mm256_store_pd(s3_x_mem, s3_x);
-			_mm256_store_pd(s3_y_mem, s3_y);
-			_mm256_store_si256((__m256i * )s3_count_mem, s3_count);
-			_mm256_store_pd(s3_x_squared_mem, s3_x_squared);
-			_mm256_store_pd(s3_y_squared_mem, s3_y_squared);
-			while(mask != 0) {
-				uint32_t b = __builtin_ctz(mask);
-				pp[s3_dx[b] + s3_dy[b] * width] = iterations - s3_count_mem[b];
-				if(!mse.get_next_point(cx_mem[b], cy_mem[b], s3_dx[b], s3_dy[b])) {
-					cleanup(mse);
+
+			update_point(s3_x, s3_y, s3_cx, s3_cy, t1);
+			if(!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+				if (!update_avx_stream<M>(mse, s3_x, s3_y, s3_cx, s3_cy, t1, i+1, s3_dx, s3_dy, s3_count, iterations, width)) {
 					return;
 				}
-				s3_count_mem[b] = iterations + 2;
-				s3_x_mem[b] = s3_y_mem[b] = s3_x_squared_mem[b] = s3_y_squared_mem[b] = 0;
-				mask = mask&~(1U<<b);
 			}
-			s3_x = _mm256_load_pd(s3_x_mem);
-			s3_y = _mm256_load_pd(s3_y_mem);
-			s3_count = _mm256_load_si256((__m256i * )s3_count_mem);
-			s3_x_squared = _mm256_load_pd(s3_x_squared_mem);
-			s3_y_squared = _mm256_load_pd(s3_y_squared_mem);
-			s3_cx = _mm256_load_pd(cx_mem);
-			s3_cy = _mm256_load_pd(cy_mem);
 		}
-		// s1_mag = s1_x_squared + s1_y_squared;
-		s1_mag = _mm256_add_pd(s1_x_squared, s1_y_squared);
-		s2_mag = _mm256_add_pd(s2_x_squared, s2_y_squared);
-		s3_mag = _mm256_add_pd(s3_x_squared, s3_y_squared);
-		// Decrement counter
-		s1_count = _mm256_sub_epi64(s1_count, one_int64);
-		s2_count = _mm256_sub_epi64(s2_count, one_int64);
-		s3_count = _mm256_sub_epi64(s3_count, one_int64);
-		// s1_y_squared = s1_y * s1_y;
-		s1_y_squared = _mm256_mul_pd(s1_y, s1_y);
-		s2_y_squared = _mm256_mul_pd(s2_y, s2_y);
-		s3_y_squared = _mm256_mul_pd(s3_y, s3_y);
-		// s1_x_squared = s1_x * s1_x;
-		s1_x_squared = _mm256_mul_pd(s1_x, s1_x);
-		s2_x_squared = _mm256_mul_pd(s2_x, s2_x);
-		s3_x_squared = _mm256_mul_pd(s3_x, s3_x);
-		// s1_y = 2 * s1_y * s1_x + s1_cy;
-		s1_y = _mm256_fmadd_pd(_mm256_add_pd(s1_x, s1_x), s1_y, s1_cy);
-		s2_y = _mm256_fmadd_pd(_mm256_add_pd(s2_x, s2_x), s2_y, s2_cy);
-		s3_y = _mm256_fmadd_pd(_mm256_add_pd(s3_x, s3_x), s3_y, s3_cy);
-		// s1_x = s1_x_squared - s1_y_squared + s1_cx;
-		s1_x = _mm256_sub_pd(s1_x_squared, _mm256_sub_pd(s1_y_squared, s1_cx));
-		s2_x = _mm256_sub_pd(s2_x_squared, _mm256_sub_pd(s2_y_squared, s2_cx));
-		s3_x = _mm256_sub_pd(s3_x_squared, _mm256_sub_pd(s3_y_squared, s3_cx));
+
+		t1 = _mm256_add_epi64(_mm256_load_si256((__m256i*)s1_count), run_iters);
+		_mm256_store_si256((__m256i*)s1_count, t1);
+		t1 = _mm256_cmpgt_epi64(t1, max_iters);
+		if (!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+			if (!update_avx_stream<M>(mse, s1_x, s1_y, s1_cx, s1_cy, t1, 0, s1_dx, s1_dy, s1_count, iterations, width)) return;
+		}
+
+		t1 = _mm256_add_epi64(_mm256_load_si256((__m256i*)s2_count), run_iters);
+		_mm256_store_si256((__m256i*)s2_count, t1);
+		t1 = _mm256_cmpgt_epi64(t1, max_iters);
+		if (!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+			if (!update_avx_stream<M>(mse, s2_x, s2_y, s2_cx, s2_cy, t1, 0, s2_dx, s2_dy, s2_count, iterations, width)) return;
+		}
+
+		t1 = _mm256_add_epi64(_mm256_load_si256((__m256i*)s3_count), run_iters);
+		_mm256_store_si256((__m256i*)s3_count, t1);
+		t1 = _mm256_cmpgt_epi64(t1, max_iters);
+		if (!_mm256_testz_pd(t1, t1)) [[unlikely]] {
+			if (!update_avx_stream<M>(mse, s3_x, s3_y, s3_cx, s3_cy, t1, 0, s3_dx, s3_dy, s3_count, iterations, width)) return;
+		}
 	}
 }
-
-


### PR DESCRIPTION
Here's one more optimization:

A lot of register space and work is spent on updating those counters.

There's no need to update them at each iteration, you can do:

```c
while (true) {
  for (i=0; i<N; i++) {
    update p;
    if (p.magnitude > 4.0) store and replace p;
  }

  p.counter += N;
  if (p.counter > iterations) store and replace p; 
}
```

Note that this is different from #1 as it still checks the magnitude each time, so there's no need for backtracking.

This brings down the number of registers per set of pixels to 4 (x, y, cx and cy), so for `avx_sheeprace3` that's 12 registers.

Then you have 4 scratch registers left. Plenty! `avx_sheeprace3` is now 20% faster than the current `avx_sheeprace2`. I also replaced the macros with inline functions.

----

I analyzed the code in uiCA, and there's still a bit of a dependency bottleneck. IPC is about 2.7 so there's room for improvement.

I don't think there's much more I can do with the current layout. Further optimizations would either need to:

1) Bring in a fourth set of pixels. You'd need to load 1 of the 4 sets of (cx,cy) from memory, I think that's doable.
2) Shorten the dep chain by removing some magnitude checks, but that idea was rejected :)